### PR TITLE
Added fix for a bug in Chromium

### DIFF
--- a/app.js
+++ b/app.js
@@ -704,6 +704,9 @@ function initCameraStream() {
 }
 
 function initCameraDrawing() {
+	// if cameraStream has vertical or horizontal resolution of 0 then it's not initialized, we retry until the browser decides to properly work
+	if (cameraStream.videoHeight == 0) setTimeout(restartCamera, 500);
+
 	const track = window.stream.getVideoTracks()[0];
 	let settings = track.getSettings();
 	let str = JSON.stringify(settings, null, 4);


### PR DESCRIPTION
Added a fix for a bug in Chromium where the browser can't initialize the camera on time, resulting in the app not being able to read it (the camera screen simply remains blank) until the user forces a refresh by changing the page zoom or size