### PR TITLE
Fix Mobile Zoom-In When Adjusting Settings

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@ html, body{
   padding: 0;
   height: 100%;
   width: 100%;
+  touch-action: manipulation;
 }
 
 body {


### PR DESCRIPTION
When adjusting settings, tapping too quickly can cause mobile browsers to zoom in. This corrects that issue.